### PR TITLE
Add pure counter functions for selection counting

### DIFF
--- a/src/counters.ts
+++ b/src/counters.ts
@@ -1,0 +1,19 @@
+export function countCharacters(text: string): number {
+  return text.length;
+}
+
+export function countWords(text: string): number {
+  return text.split(/\s+/).filter(token => token.length > 0).length;
+}
+
+export function countLetters(text: string): number {
+  return (text.match(/\p{L}/gu) ?? []).length;
+}
+
+export function countNumbers(text: string): number {
+  return (text.match(/\p{N}/gu) ?? []).length;
+}
+
+export function countSpecial(text: string): number {
+  return (text.match(/[^\p{L}\p{N}\s]/gu) ?? []).length;
+}

--- a/src/test/suite/counters.test.ts
+++ b/src/test/suite/counters.test.ts
@@ -1,0 +1,57 @@
+import * as assert from 'assert';
+import {
+  countCharacters,
+  countLetters,
+  countNumbers,
+  countSpecial,
+  countWords
+} from '../../counters';
+
+suite('counters', () => {
+  test('empty input returns 0 for every counter', () => {
+    assert.strictEqual(countCharacters(''), 0);
+    assert.strictEqual(countWords(''), 0);
+    assert.strictEqual(countLetters(''), 0);
+    assert.strictEqual(countNumbers(''), 0);
+    assert.strictEqual(countSpecial(''), 0);
+  });
+
+  test('ASCII-only: "Hello, World 123!"', () => {
+    const input = 'Hello, World 123!';
+    assert.strictEqual(countCharacters(input), 17);
+    assert.strictEqual(countWords(input), 3);
+    assert.strictEqual(countLetters(input), 10);
+    assert.strictEqual(countNumbers(input), 3);
+    assert.strictEqual(countSpecial(input), 2);
+  });
+
+  test('Unicode letters and digits: "café résumé 4²"', () => {
+    const input = 'café résumé 4²';
+    assert.strictEqual(countCharacters(input), 14);
+    assert.strictEqual(countWords(input), 3);
+    assert.strictEqual(countLetters(input), 10);
+    assert.strictEqual(countNumbers(input), 2);
+    assert.strictEqual(countSpecial(input), 0);
+  });
+
+  test('multiline: newlines are whitespace, consecutive whitespace collapses for words', () => {
+    const input = 'line one\nline two\n\nline three';
+    assert.strictEqual(countCharacters(input), 29);
+    assert.strictEqual(countWords(input), 6);
+    assert.strictEqual(countLetters(input), 23);
+    assert.strictEqual(countNumbers(input), 0);
+    assert.strictEqual(countSpecial(input), 0);
+  });
+
+  test('multi-range aggregate: scalars sum at the call site', () => {
+    const ranges = ['Hello,', ' World ', '!42'];
+    const sum = (fn: (s: string) => number): number =>
+      ranges.reduce((acc, t) => acc + fn(t), 0);
+
+    assert.strictEqual(sum(countCharacters), 16);
+    assert.strictEqual(sum(countWords), 3);
+    assert.strictEqual(sum(countLetters), 10);
+    assert.strictEqual(sum(countNumbers), 2);
+    assert.strictEqual(sum(countSpecial), 2);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/counters.ts` exporting five pure scalar functions (`countCharacters`, `countWords`, `countLetters`, `countNumbers`, `countSpecial`). No `vscode` import, no other internal imports — module is self-contained and unit-testable in isolation.
- Add `src/test/suite/counters.test.ts` covering the five categories CLAUDE.md mandates: empty input, ASCII, Unicode letters/digits, multiline, and multi-range aggregate (aggregation done at the call site via `reduce`, since the counters themselves are scalars).
- Wiring into the status bar lands in #8.

## Verification

- `npx tsc --noEmit` ✅
- `node esbuild.js --production` ✅
- `npx eslint src --ext ts` ✅
- `npm test` ✅ (6 passing — pre-existing `extension is present` plus 5 new counter tests)

## CHANGELOG / README skips (intentional)

- **No CHANGELOG entry.** Counter functions are not yet user-visible — they ship behind the status bar wiring in #8. Flagging here so the reviewer's CHANGELOG check is a conscious skip.
- **No README update.** No new commands, settings, or keybindings.

Closes #7