### PR TITLE
Wire status bar to display live selection counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ All notable changes to this project are documented here. The format follows [Kee
 
 - Initial project scaffold (package.json, TypeScript build, esbuild bundle, ESLint, vscode-test runner, command and configuration registrations as stubs).
 - Marketplace icon (images/icon.png) — yellow highlight slab inside cyan brackets, indigo numeral.
+- Live selection counts in the status bar (characters, words, letters, numbers, special characters), with per-category visibility controlled by `selectionCount.show.*` settings and rendering controlled by `selectionCount.format` (text or icons).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All commands are available through the Command Palette (search for "Selection Co
 | `selectionCount.show.numbers` | `false` | Include digit count (0–9) in the status bar readout. |
 | `selectionCount.show.specialCharacters` | `false` | Include special-character count in the status bar readout. |
 | `selectionCount.enabled` | `true` | Show the Selection Count status bar item at all. |
+| `selectionCount.format` | `"text"` | How counts are rendered in the status bar. `"text"` for full words, `"icons"` for VS Code codicons. |
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,16 @@
           "type": "boolean",
           "default": true,
           "description": "Show the Selection Count status bar item."
+        },
+        "selectionCount.format": {
+          "type": "string",
+          "enum": ["text", "icons"],
+          "enumDescriptions": [
+            "Plain words: '42 chars, 8 words'",
+            "VS Code codicons with numbers: '$(symbol-string) 42  $(whole-word) 8'"
+          ],
+          "default": "text",
+          "description": "How counts are rendered in the status bar."
         }
       }
     }

--- a/src/buildReadout.ts
+++ b/src/buildReadout.ts
@@ -1,0 +1,62 @@
+export interface SelectionCounts {
+  characters: number;
+  words: number;
+  letters: number;
+  numbers: number;
+  special: number;
+}
+
+export interface DisplayFlags {
+  characters: boolean;
+  words: boolean;
+  letters: boolean;
+  numbers: boolean;
+  special: boolean;
+}
+
+export type DisplayFormat = 'text' | 'icons';
+
+const ORDER: ReadonlyArray<keyof SelectionCounts> = [
+  'characters',
+  'words',
+  'letters',
+  'numbers',
+  'special'
+];
+
+const LABELS: Record<keyof SelectionCounts, { singular: string; plural: string }> = {
+  characters: { singular: 'char', plural: 'chars' },
+  words: { singular: 'word', plural: 'words' },
+  letters: { singular: 'letter', plural: 'letters' },
+  numbers: { singular: 'num', plural: 'nums' },
+  special: { singular: 'special', plural: 'special' }
+};
+
+const CODICONS: Record<keyof SelectionCounts, string> = {
+  characters: '$(symbol-string)',
+  words: '$(whole-word)',
+  letters: '$(case-sensitive)',
+  numbers: '$(symbol-number)',
+  special: '$(symbol-operator)'
+};
+
+export function buildReadout(
+  counts: SelectionCounts,
+  flags: DisplayFlags,
+  format: DisplayFormat
+): string {
+  const enabled = ORDER.filter(key => flags[key]);
+  if (enabled.length === 0) {
+    return '';
+  }
+  if (format === 'icons') {
+    return enabled.map(key => `${CODICONS[key]} ${counts[key]}`).join('  ');
+  }
+  return enabled
+    .map(key => {
+      const value = counts[key];
+      const { singular, plural } = LABELS[key];
+      return `${value} ${value === 1 ? singular : plural}`;
+    })
+    .join(', ');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
+import { createStatusBar } from './statusBar';
 
 export function activate(context: vscode.ExtensionContext): void {
+  createStatusBar(context);
+
   const register = (command: string, handler: () => void): void => {
     context.subscriptions.push(vscode.commands.registerCommand(command, handler));
   };

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import {
+  countCharacters,
+  countLetters,
+  countNumbers,
+  countSpecial,
+  countWords
+} from './counters';
+import {
+  DisplayFlags,
+  DisplayFormat,
+  SelectionCounts,
+  buildReadout
+} from './buildReadout';
+
+export function createStatusBar(context: vscode.ExtensionContext): void {
+  const item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+  context.subscriptions.push(item);
+
+  const update = (): void => {
+    const config = vscode.workspace.getConfiguration('selectionCount');
+    if (!config.get<boolean>('enabled', true)) {
+      item.hide();
+      return;
+    }
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      item.hide();
+      return;
+    }
+
+    const ranges = editor.selections.filter(s => !s.isEmpty);
+    if (ranges.length === 0) {
+      item.hide();
+      return;
+    }
+
+    const counts = aggregateCounts(editor, ranges);
+    const flags = readFlags(config);
+    const format = config.get<DisplayFormat>('format', 'text');
+
+    const readout = buildReadout(counts, flags, format);
+    if (readout === '') {
+      item.hide();
+      return;
+    }
+
+    item.text = readout;
+    item.tooltip = buildTooltip(counts, flags);
+    item.show();
+  };
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeTextEditorSelection(update),
+    vscode.window.onDidChangeActiveTextEditor(update),
+    vscode.workspace.onDidChangeConfiguration(event => {
+      if (event.affectsConfiguration('selectionCount')) {
+        update();
+      }
+    })
+  );
+
+  update();
+}
+
+function aggregateCounts(
+  editor: vscode.TextEditor,
+  ranges: ReadonlyArray<vscode.Selection>
+): SelectionCounts {
+  return ranges.reduce<SelectionCounts>(
+    (acc, range) => {
+      const text = editor.document.getText(range);
+      return {
+        characters: acc.characters + countCharacters(text),
+        words: acc.words + countWords(text),
+        letters: acc.letters + countLetters(text),
+        numbers: acc.numbers + countNumbers(text),
+        special: acc.special + countSpecial(text)
+      };
+    },
+    { characters: 0, words: 0, letters: 0, numbers: 0, special: 0 }
+  );
+}
+
+function readFlags(config: vscode.WorkspaceConfiguration): DisplayFlags {
+  return {
+    characters: config.get<boolean>('show.characters', true),
+    words: config.get<boolean>('show.words', true),
+    letters: config.get<boolean>('show.letters', false),
+    numbers: config.get<boolean>('show.numbers', false),
+    special: config.get<boolean>('show.specialCharacters', false)
+  };
+}
+
+function buildTooltip(counts: SelectionCounts, flags: DisplayFlags): string {
+  const lines = ['Selection Count'];
+  if (flags.characters) {
+    lines.push(`Characters: ${counts.characters}`);
+  }
+  if (flags.words) {
+    lines.push(`Words: ${counts.words}`);
+  }
+  if (flags.letters) {
+    lines.push(`Letters: ${counts.letters}`);
+  }
+  if (flags.numbers) {
+    lines.push(`Numbers: ${counts.numbers}`);
+  }
+  if (flags.special) {
+    lines.push(`Special: ${counts.special}`);
+  }
+  return lines.join('\n');
+}

--- a/src/test/suite/buildReadout.test.ts
+++ b/src/test/suite/buildReadout.test.ts
@@ -1,0 +1,112 @@
+import * as assert from 'assert';
+import {
+  DisplayFlags,
+  SelectionCounts,
+  buildReadout
+} from '../../buildReadout';
+
+const counts = (c = 0, w = 0, l = 0, n = 0, s = 0): SelectionCounts => ({
+  characters: c,
+  words: w,
+  letters: l,
+  numbers: n,
+  special: s
+});
+
+const flagsAllOff: DisplayFlags = {
+  characters: false,
+  words: false,
+  letters: false,
+  numbers: false,
+  special: false
+};
+const flagsDefault: DisplayFlags = {
+  characters: true,
+  words: true,
+  letters: false,
+  numbers: false,
+  special: false
+};
+const flagsAllOn: DisplayFlags = {
+  characters: true,
+  words: true,
+  letters: true,
+  numbers: true,
+  special: true
+};
+
+suite('buildReadout', () => {
+  test('all flags off returns empty string in both formats', () => {
+    assert.strictEqual(buildReadout(counts(42, 8), flagsAllOff, 'text'), '');
+    assert.strictEqual(buildReadout(counts(42, 8), flagsAllOff, 'icons'), '');
+  });
+
+  test('text mode default flags renders comma-separated chars+words', () => {
+    assert.strictEqual(
+      buildReadout(counts(42, 8), flagsDefault, 'text'),
+      '42 chars, 8 words'
+    );
+  });
+
+  test('text mode all flags on renders all five in fixed order', () => {
+    assert.strictEqual(
+      buildReadout(counts(42, 8, 30, 3, 9), flagsAllOn, 'text'),
+      '42 chars, 8 words, 30 letters, 3 nums, 9 special'
+    );
+  });
+
+  test('text mode applies singular vs plural per count', () => {
+    assert.strictEqual(
+      buildReadout(counts(1, 1, 1, 1, 1), flagsAllOn, 'text'),
+      '1 char, 1 word, 1 letter, 1 num, 1 special'
+    );
+    assert.strictEqual(
+      buildReadout(counts(2, 2, 2, 2, 2), flagsAllOn, 'text'),
+      '2 chars, 2 words, 2 letters, 2 nums, 2 special'
+    );
+  });
+
+  test('icon mode renders codicon syntax with double-space separator', () => {
+    assert.strictEqual(
+      buildReadout(counts(42, 8), flagsDefault, 'icons'),
+      '$(symbol-string) 42  $(whole-word) 8'
+    );
+  });
+
+  test('icon mode all flags on includes the five codicons in fixed order', () => {
+    const result = buildReadout(counts(1, 2, 3, 4, 5), flagsAllOn, 'icons');
+    const expected =
+      '$(symbol-string) 1  $(whole-word) 2  $(case-sensitive) 3  $(symbol-number) 4  $(symbol-operator) 5';
+    assert.strictEqual(result, expected);
+
+    const positions = [
+      '$(symbol-string)',
+      '$(whole-word)',
+      '$(case-sensitive)',
+      '$(symbol-number)',
+      '$(symbol-operator)'
+    ].map(token => result.indexOf(token));
+    for (let i = 1; i < positions.length; i++) {
+      assert.ok(positions[i] > positions[i - 1], 'codicon order is fixed');
+    }
+  });
+
+  test('codicon syntax appears verbatim only in icon mode', () => {
+    const textResult = buildReadout(counts(1, 1, 1, 1, 1), flagsAllOn, 'text');
+    assert.ok(!textResult.includes('$('), 'no codicon syntax in text mode');
+
+    const iconResult = buildReadout(counts(1, 1, 1, 1, 1), flagsAllOn, 'icons');
+    assert.ok(iconResult.includes('$('), 'codicon syntax present in icon mode');
+  });
+
+  test('zero count for an enabled category is included not skipped', () => {
+    assert.strictEqual(
+      buildReadout(counts(0, 0), flagsDefault, 'text'),
+      '0 chars, 0 words'
+    );
+    assert.strictEqual(
+      buildReadout(counts(0, 0), flagsDefault, 'icons'),
+      '$(symbol-string) 0  $(whole-word) 0'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/buildReadout.ts` — pure helper that renders `SelectionCounts` + `DisplayFlags` to a status-bar string in fixed order (characters → words → letters → numbers → special), with `'text'` (`"42 chars, 8 words"`) and `'icons'` (`"$(symbol-string) 42  $(whole-word) 8"`) formats. Returns `''` when no flags are on.
- Add `src/statusBar.ts` — vscode-coupled wiring. One `StatusBarItem` (right, priority 100). Subscribes to `onDidChangeTextEditorSelection`, `onDidChangeActiveTextEditor`, and `onDidChangeConfiguration` (filtered to `selectionCount.*`). Does **not** subscribe to `onDidChangeTextDocument` per CLAUDE.md.
- `src/extension.ts` calls `createStatusBar(context)` from `activate()`. Stub commands unchanged (replaced in #9).
- `package.json` registers the 7th setting `selectionCount.format` (`"text"` default, `"icons"` alternative, `enumDescriptions` populated).
- `README.md` documents the new setting; `CHANGELOG.md` records the user-visible change under `[Unreleased] → ### Added`.
- Multi-range selections aggregate at the call site (each non-empty range summed via `reduce`). Item hides when every range is empty, all show flags are off, or `enabled` is false.

## Verification

- `npx tsc --noEmit` ✅
- `node esbuild.js --production` ✅
- `npx eslint src --ext ts` ✅
- `npm test` ✅ — 14 passing (extension presence + 5 counters + 8 buildReadout)
- Grep verified `onDidChangeTextDocument` does not appear in `src/statusBar.ts`.

## Note on manual F5 verification

I implemented the codicon mapping verbatim from the issue plan (`symbol-string`, `whole-word`, `case-sensitive`, `symbol-number`, `symbol-operator`) but did not visually F5 the extension to confirm each codicon renders. All five are standard codicons in the VS Code catalog, so I expect them to render correctly; if any glyph is missing or wrong, swap it in a follow-up.

## Out of scope (follow-ups)

- Real implementations of `selectionCount.toggleVisibility` and `selectionCount.configureDisplay` — addressed in #9.

Closes #8