### PR TITLE
Implement Toggle Visibility and Configure Display commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ All notable changes to this project are documented here. The format follows [Kee
 - Initial project scaffold (package.json, TypeScript build, esbuild bundle, ESLint, vscode-test runner, command and configuration registrations as stubs).
 - Marketplace icon (images/icon.png) — yellow highlight slab inside cyan brackets, indigo numeral.
 - Live selection counts in the status bar (characters, words, letters, numbers, special characters), with per-category visibility controlled by `selectionCount.show.*` settings and rendering controlled by `selectionCount.format` (text or icons).
+- Toggle Visibility and Configure Display commands now do what they say (replacing v0.1.0 stubs).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,19 +1,63 @@
 import * as vscode from 'vscode';
 import { createStatusBar } from './statusBar';
 
+type ShowKey =
+  | 'show.characters'
+  | 'show.words'
+  | 'show.letters'
+  | 'show.numbers'
+  | 'show.specialCharacters';
+
+interface ConfigureItem extends vscode.QuickPickItem {
+  configKey: ShowKey;
+}
+
+const DISPLAY_CATEGORIES: ReadonlyArray<{ label: string; configKey: ShowKey }> = [
+  { label: 'Characters', configKey: 'show.characters' },
+  { label: 'Words', configKey: 'show.words' },
+  { label: 'Letters', configKey: 'show.letters' },
+  { label: 'Numbers', configKey: 'show.numbers' },
+  { label: 'Special characters', configKey: 'show.specialCharacters' }
+];
+
 export function activate(context: vscode.ExtensionContext): void {
   createStatusBar(context);
 
-  const register = (command: string, handler: () => void): void => {
+  const register = (command: string, handler: () => unknown): void => {
     context.subscriptions.push(vscode.commands.registerCommand(command, handler));
   };
 
-  register('selectionCount.toggleVisibility', () => {
-    throw new Error('Selection Count: Toggle Visibility is not yet implemented');
+  register('selectionCount.toggleVisibility', async () => {
+    const config = vscode.workspace.getConfiguration('selectionCount');
+    const current = config.get<boolean>('enabled', true);
+    await config.update('enabled', !current, vscode.ConfigurationTarget.Global);
   });
 
-  register('selectionCount.configureDisplay', () => {
-    throw new Error('Selection Count: Configure Display is not yet implemented');
+  register('selectionCount.configureDisplay', async () => {
+    const config = vscode.workspace.getConfiguration('selectionCount');
+    const items: ConfigureItem[] = DISPLAY_CATEGORIES.map(cat => ({
+      label: cat.label,
+      picked: config.get<boolean>(cat.configKey, false),
+      configKey: cat.configKey
+    }));
+
+    const picked = await vscode.window.showQuickPick(items, {
+      canPickMany: true,
+      placeHolder: 'Toggle which counts appear in the status bar'
+    });
+
+    if (picked === undefined) {
+      return;
+    }
+
+    const pickedKeys = new Set(picked.map(p => p.configKey));
+    for (const cat of DISPLAY_CATEGORIES) {
+      await config.update(
+        cat.configKey,
+        pickedKeys.has(cat.configKey),
+        vscode.ConfigurationTarget.Global
+      );
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- Replace the two throwing stubs in `src/extension.ts` with real bodies. Both write to `ConfigurationTarget.Global`; the status bar reacts via the existing `onDidChangeConfiguration` listener (no new wiring needed).
- `selectionCount.toggleVisibility`: read `selectionCount.enabled`, write the inverted value. No notification — the status bar appearing/disappearing is the feedback.
- `selectionCount.configureDisplay`: multi-select `showQuickPick` over the five categories, pre-picked from current `selectionCount.show.*` values. On submit, every category is written (true if picked, false if not). On cancel (`undefined`) no writes happen.
- Widen the local `register` helper from `() => void` to `() => unknown` so it accepts the async handlers; `vscode.commands.registerCommand` already awaits returned promises.
- Add a `DISPLAY_CATEGORIES` table at module scope mapping label → config key.

## Verification

- `npx tsc --noEmit` ✅
- `node esbuild.js --production` ✅
- `npx eslint src --ext ts` ✅
- `npm test` ✅ — 14 passing (no command-handler unit tests; per the issue plan those would require configuration-API mocking, deferred)
- Grep confirms no `'not yet implemented'` strings remain in `src/`.

## Note on manual F5 verification

I ran the gates but did not personally F5 the extension to walk through the picker and toggle flow. The implementation is a literal transcription of the plan's code blocks. If anything in the QuickPick UX feels off (pre-pick state, placeholder text, post-write status-bar refresh), happy to do a follow-up.

## CHANGELOG / README skips

- **CHANGELOG**: entry added under `[Unreleased] → ### Added`.
- **README**: no update needed — the Commands table already describes both commands accurately. Flagging here so the reviewer's README check is a conscious skip.

Closes #9