### PR TITLE
Prepare CHANGELOG for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-04
+
 ### Added
 
 - Initial project scaffold (package.json, TypeScript build, esbuild bundle, ESLint, vscode-test runner, command and configuration registrations as stubs).
 - Marketplace icon (images/icon.png) — yellow highlight slab inside cyan brackets, indigo numeral.
 - Live selection counts in the status bar (characters, words, letters, numbers, special characters), with per-category visibility controlled by `selectionCount.show.*` settings and rendering controlled by `selectionCount.format` (text or icons).
-- Toggle Visibility and Configure Display commands now do what they say (replacing v0.1.0 stubs).
+- `Selection Count: Toggle Visibility` and `Selection Count: Configure Display` commands.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Rename `## [Unreleased]` → `## [0.1.0] - 2026-05-04` in `CHANGELOG.md` and insert a fresh empty `## [Unreleased]` section above it for the next cycle.
- Tighten the Toggle Visibility / Configure Display entry — drop the `(replacing v0.1.0 stubs)` parenthetical that reads awkwardly when collapsed into the v0.1.0 entry itself, since the stubs never shipped to users.
- No code, `package.json`, or test changes. The `version` field in `package.json` is already `"0.1.0"` from the scaffold.

## Verification

- `npx tsc --noEmit` ✅, `node esbuild.js --production` ✅, `npx eslint src --ext ts` ✅. `npm test` skipped — no source change.
- Diff is 3 lines added, 1 removed in `CHANGELOG.md` only.

## Why `Refs` and not `Closes`

Per the issue body, this PR is the agent-scope half of the release. The human-driven publish steps still need to happen after merge — `vsce publish`, push the `v0.1.0` tag, delete the local `.vsix`, verify the marketplace listing, comment with the URL, then close #11 manually. Using `Refs #11` so the issue stays open through those steps.

Refs #11