### PR TITLE
Write config to the scope where the setting is already overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 - Wording cleanup: README and settings descriptions now say "number" (Unicode `\p{N}`) instead of "digit", which better reflects what the counter actually matches (decimal digits, fractions like `½`, superscripts like `²`, Roman numerals, etc.). (#24)
 
+### Fixed
+
+- Toggle Visibility and Configure Display now write to the same configuration scope where the setting is currently overridden, instead of always writing to user (Global) settings. Previously, if a workspace had `selectionCount.*` overridden, the commands appeared to do nothing because the workspace value continued to win after a Global write. (#22)
+
 ## [0.1.0] - 2026-05-04
 
 ### Added

--- a/src/configScope.ts
+++ b/src/configScope.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+export interface ScopedInspect<T> {
+  workspaceFolderValue?: T;
+  workspaceValue?: T;
+  globalValue?: T;
+}
+
+export function resolveWriteTarget<T>(
+  inspect: ScopedInspect<T> | undefined
+): vscode.ConfigurationTarget {
+  if (inspect?.workspaceFolderValue !== undefined) {
+    return vscode.ConfigurationTarget.WorkspaceFolder;
+  }
+  if (inspect?.workspaceValue !== undefined) {
+    return vscode.ConfigurationTarget.Workspace;
+  }
+  return vscode.ConfigurationTarget.Global;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { resolveWriteTarget } from './configScope';
 import { createStatusBar } from './statusBar';
 
 type ShowKey =
@@ -30,7 +31,8 @@ export function activate(context: vscode.ExtensionContext): void {
   register('selectionCount.toggleVisibility', async () => {
     const config = vscode.workspace.getConfiguration('selectionCount');
     const current = config.get<boolean>('enabled', true);
-    await config.update('enabled', !current, vscode.ConfigurationTarget.Global);
+    const target = resolveWriteTarget(config.inspect<boolean>('enabled'));
+    await config.update('enabled', !current, target);
   });
 
   register('selectionCount.configureDisplay', async () => {
@@ -52,11 +54,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
     const pickedKeys = new Set(picked.map(p => p.configKey));
     for (const cat of DISPLAY_CATEGORIES) {
-      await config.update(
-        cat.configKey,
-        pickedKeys.has(cat.configKey),
-        vscode.ConfigurationTarget.Global
-      );
+      const target = resolveWriteTarget(config.inspect<boolean>(cat.configKey));
+      await config.update(cat.configKey, pickedKeys.has(cat.configKey), target);
     }
   });
 }

--- a/src/test/suite/configScope.test.ts
+++ b/src/test/suite/configScope.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { resolveWriteTarget } from '../../configScope';
+
+suite('resolveWriteTarget', () => {
+  test('undefined inspect → Global', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>(undefined),
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  test('empty inspect (nothing set anywhere) → Global', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>({}),
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  test('only Global set → Global', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>({ globalValue: true }),
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  test('only Workspace set → Workspace', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>({ workspaceValue: false }),
+      vscode.ConfigurationTarget.Workspace
+    );
+  });
+
+  test('Global and Workspace both set → Workspace (workspace wins)', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>({ globalValue: true, workspaceValue: false }),
+      vscode.ConfigurationTarget.Workspace
+    );
+  });
+
+  test('all three set → WorkspaceFolder (most specific wins)', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>({
+        globalValue: true,
+        workspaceValue: false,
+        workspaceFolderValue: true
+      }),
+      vscode.ConfigurationTarget.WorkspaceFolder
+    );
+  });
+
+  test('explicit false at Workspace counts as set, not unset', () => {
+    assert.strictEqual(
+      resolveWriteTarget<boolean>({ workspaceValue: false }),
+      vscode.ConfigurationTarget.Workspace
+    );
+  });
+});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -5,4 +5,34 @@ suite('Selection Count Extension', () => {
   test('extension is present', () => {
     assert.ok(vscode.extensions.getExtension('dvlprlife.selection-count'));
   });
+
+  suite('toggleVisibility command', () => {
+    let originalGlobal: boolean | undefined;
+
+    suiteSetup(async () => {
+      const config = vscode.workspace.getConfiguration('selectionCount');
+      originalGlobal = config.inspect<boolean>('enabled')?.globalValue;
+    });
+
+    suiteTeardown(async () => {
+      const config = vscode.workspace.getConfiguration('selectionCount');
+      await config.update(
+        'enabled',
+        originalGlobal,
+        vscode.ConfigurationTarget.Global
+      );
+    });
+
+    test('flips the effective value when only Global is set', async () => {
+      const config = vscode.workspace.getConfiguration('selectionCount');
+      await config.update('enabled', true, vscode.ConfigurationTarget.Global);
+      assert.strictEqual(config.get<boolean>('enabled'), true);
+
+      await vscode.commands.executeCommand('selectionCount.toggleVisibility');
+
+      const after = vscode.workspace.getConfiguration('selectionCount');
+      assert.strictEqual(after.get<boolean>('enabled'), false);
+      assert.strictEqual(after.inspect<boolean>('enabled')?.globalValue, false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `Toggle Visibility` and `Configure Display` previously wrote to `ConfigurationTarget.Global` unconditionally. If a workspace had any `selectionCount.*` setting overridden, the workspace value kept winning after the Global write — the command looked silently broken.
- Both commands now call `config.inspect(key)` and route the write to the most-specific scope that already has a value defined: WorkspaceFolder → Workspace → Global. If nothing is set anywhere, falls back to Global. (Issue Option 1 — "inspect-then-update".)
- New `src/configScope.ts` with a pure `resolveWriteTarget(inspect)` helper.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node esbuild.js --production` passes
- [x] `npm test` — 22/22 passing (14 prior + 7 new resolver unit tests + 1 integration test that flips the toggle end-to-end)
- [ ] Reviewer: confirm the resolution order matches VS Code's effective-value order (WorkspaceFolder > Workspace > Global)
- [ ] Manual smoke: with a workspace that overrides `selectionCount.enabled`, run `Selection Count: Toggle Visibility` and confirm the status bar visibility actually changes (before this PR, it would not)

## Notes for reviewer

- Pure unit tests cover all four AC scenarios (only-Global, only-Workspace, both set with workspace winning, neither set) plus the folder-override case. Integration coverage of the workspace and folder cases would require setting up a workspace folder in the test runner, which `.vscode-test.mjs` doesn't currently do — the resolver's correctness combined with VS Code's documented `update(key, val, target)` semantics covers those paths.
- No README change — the user-visible behavior described in the README ("Toggle Visibility shows or hides…") is unchanged. This PR makes the existing description actually true in the workspace-override case.

Closes #22