### PR TITLE
Count characters by code point, not UTF-16 code units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. The format follows [Kee
 ### Changed
 
 - Wording cleanup: README and settings descriptions now say "number" (Unicode `\p{N}`) instead of "digit", which better reflects what the counter actually matches (decimal digits, fractions like `½`, superscripts like `²`, Roman numerals, etc.). (#24)
+- Character count now counts Unicode code points (so emoji count as 1, not 2). Reconciles with letter/number/special counts. (#23)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ These are non-negotiable:
 - **React to selection changes, not document changes.** Subscribe to `onDidChangeTextEditorSelection` (and `onDidChangeActiveTextEditor`). Do not subscribe to `onDidChangeTextDocument` — the selection event already fires on edits inside the active editor, and subscribing to both causes double work.
 - **Empty selection = hidden item.** When the selection is empty (cursor only), hide the status bar item rather than showing zeros. The whole feature is *selection* count.
 - **Definitions:**
-  - **Character** — every code unit in the selection, including whitespace and newlines (`selection.length` semantics — count grapheme-naive code units, matching what VS Code's built-in selection indicator shows).
+  - **Character** — every Unicode code point in the selection, including whitespace and newlines. Implementation: `[...text].length`. Counts emoji and other supplementary-plane characters as 1 (not 2 UTF-16 code units), so the readout reconciles: characters = letters + numbers + special + whitespace. Combining marks still count separately — a decomposed `é` (`e` + U+0301) is two characters.
   - **Word** — whitespace-separated non-empty tokens (`/\s+/` split, filter empties).
   - **Letter** — matches `/\p{L}/u` (Unicode letter category), not just `[A-Za-z]`. Update the README's "A–Z" wording if this ever needs to be ASCII-only.
   - **Number** — matches `/\p{N}/u` (Unicode number category).

--- a/src/counters.ts
+++ b/src/counters.ts
@@ -1,5 +1,5 @@
 export function countCharacters(text: string): number {
-  return text.length;
+  return [...text].length;
 }
 
 export function countWords(text: string): number {

--- a/src/test/suite/counters.test.ts
+++ b/src/test/suite/counters.test.ts
@@ -54,4 +54,46 @@ suite('counters', () => {
     assert.strictEqual(sum(countNumbers), 2);
     assert.strictEqual(sum(countSpecial), 2);
   });
+
+  test('supplementary-plane character (emoji) counts as 1 character, not 2 code units', () => {
+    assert.strictEqual(countCharacters('🎉'), 1);
+    assert.strictEqual(countCharacters('🎉🎉🎉'), 3);
+  });
+
+  test('supplementary-plane letter (mathematical script) is 1 character and 1 letter', () => {
+    const input = '𝓗𝓮𝓵𝓵𝓸';
+    assert.strictEqual(countCharacters(input), 5);
+    assert.strictEqual(countLetters(input), 5);
+    assert.strictEqual(countNumbers(input), 0);
+    assert.strictEqual(countSpecial(input), 0);
+  });
+
+  test('supplementary-plane digit (mathematical double-struck) is 1 character and 1 number', () => {
+    const input = '𝟙𝟚𝟛';
+    assert.strictEqual(countCharacters(input), 3);
+    assert.strictEqual(countLetters(input), 0);
+    assert.strictEqual(countNumbers(input), 3);
+    assert.strictEqual(countSpecial(input), 0);
+  });
+
+  test('reconciliation: characters = letters + numbers + special + whitespace, including emoji', () => {
+    const input = 'Hi 🎉 42!';
+    const whitespace = (input.match(/\s/gu) ?? []).length;
+    const total =
+      countLetters(input) +
+      countNumbers(input) +
+      countSpecial(input) +
+      whitespace;
+    assert.strictEqual(countCharacters(input), total);
+    assert.strictEqual(countCharacters(input), 8);
+  });
+
+  test('combining marks: code-point counting, not grapheme clusters', () => {
+    const composed = 'é';
+    const decomposed = 'é';
+    assert.strictEqual(countCharacters(composed), 1);
+    assert.strictEqual(countCharacters(decomposed), 2);
+    assert.strictEqual(countLetters(composed), 1);
+    assert.strictEqual(countLetters(decomposed), 1);
+  });
 });


### PR DESCRIPTION
## Summary

- `countCharacters` now uses `[...text].length` (Unicode code points) instead of `text.length` (UTF-16 code units).
- Selections containing supplementary-plane characters now reconcile: `chars = letters + numbers + special + whitespace`. A selection of `🎉🎉🎉` reports `chars: 3, special: 3` (was: `chars: 6, special: 3`).
- CLAUDE.md "Character" definition updated; the previous "matches VS Code's built-in selection indicator" rationale is dropped — the whole point of this extension is to show *more* than the built-in, and reconciling the math is the bigger win.
- Combining marks still count separately (grapheme-cluster counting via `Intl.Segmenter` is out of scope per the issue).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node esbuild.js --production` passes
- [x] `npm test` — 27/27 passing (22 prior + 5 new: emoji, supplementary-plane letters, supplementary-plane digits, reconciliation, combining marks)
- [x] Reviewer: confirm CLAUDE.md amendment is acceptable and the divergence from VS Code's built-in indicator is the intended trade

Closes #23