### PR TITLE
Prepare CHANGELOG and version bump for v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-09
+
 ### Changed
 
 - Wording cleanup: README and settings descriptions now say "number" (Unicode `\p{N}`) instead of "digit", which better reflects what the counter actually matches (decimal digits, fractions like `½`, superscripts like `²`, Roman numerals, etc.). (#24)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "selection-count",
   "displayName": "Selection Count",
   "description": "Live selection counts (characters, words, letters, numbers, special characters) in the VS Code status bar.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- `package.json` `version`: `0.1.0` → `0.1.1`.
- `CHANGELOG.md`: rolled `[Unreleased]` → `[0.1.1] - 2026-05-09`; fresh empty `[Unreleased]` added above for the next cycle.
- No code changes — housekeeping only.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node esbuild.js --production` passes
- [x] `npm test` — 27/27 passing
- [ ] After merge: `vsce publish`, tag `v0.1.1` on the merged commit, delete the local `.vsix`

Closes #28