### PR TITLE
Add Extension Tests debug configuration to .vscode/launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,19 @@
         "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "npm: compile"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/dist/test/suite/index"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the `Extension Tests` debug configuration that Markdown-Foundry and AL-EventLens already expose, so contributors can F5 into the vscode-test runner under the debugger.

The test harness was already wired through `@vscode/test-cli` and runnable via `npm test` — this just exposes a debug-launcher entry for it.

No CHANGELOG entry — contributor-facing only.
No README change.

Closes #31