### PR TITLE
Add contributor scaffolding: issue forms, PR template, CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Something in Selection Count isn't working as documented.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: The status bar shows ... but I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps, including the text you selected if the bug is about a count being wrong. Paste the selection inside a code block so whitespace and special characters survive.
+      placeholder: |
+        1. Open a file containing ...
+        2. Select ...
+        3. Look at the status bar
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to see instead. The counter definitions (character, word, letter, number, special) are documented in the README's Features section.
+    validations:
+      required: true
+  - type: textarea
+    id: settings
+    attributes:
+      label: Relevant settings
+      description: Any non-default `selectionCount.*` settings (e.g. `selectionCount.format`, `selectionCount.show.*`), and whether they are set at the User or Workspace scope.
+      placeholder: '"selectionCount.format": "icons" (Workspace)'
+    validations:
+      required: false
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension version
+      placeholder: 0.1.1
+    validations:
+      required: true
+  - type: input
+    id: vscode-version
+    attributes:
+      label: VS Code version
+      description: From Help > About (1.85.0 or later is required).
+      placeholder: 1.85.0
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Windows 11 / macOS 14 / Ubuntu 24.04
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new capability or a change to existing behavior.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What should change?
+      description: Describe the feature or behavior change you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: The motivation — what problem does this solve, and in what situation did you hit it?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Optional but appreciated — a checklist of what "done" looks like. Issues in this repo are worked from their body, so concrete criteria speed things up.
+      placeholder: |
+        - [ ] A new `selectionCount.show.lines` setting exists, default false
+        - [ ] When enabled, the readout includes a line count
+        - [ ] README Settings table updated
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about, if any.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- PR body convention (CLAUDE.md): open with ## Summary (1-3 bullets), end with Closes #{number}. One PR per issue. -->
+
+## Summary
+
+-
+
+## Checklist
+
+<!-- These mirror what CI (.github/workflows/build.yml) runs on every PR. -->
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `node esbuild.js --production` passes
+- [ ] `npm test` passes (its `pretest` also runs the full compile and ESLint)
+- [ ] `CHANGELOG.md` `[Unreleased]` updated if this is a user-visible change (see "CHANGELOG maintenance" in CLAUDE.md)
+- [ ] `README.md` updated if this adds or changes a command, setting, or keybinding (see "README maintenance" in CLAUDE.md)
+
+Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Selection Count
+
+Thanks for your interest in contributing. This is a small VS Code extension; the rules below are short but enforced — pull requests are reviewed against [CLAUDE.md](CLAUDE.md), which is the authoritative spec for the workflow, the counter definitions, and the code style.
+
+## Setup
+
+- Node.js 20.x (what CI uses) and VS Code 1.85 or later.
+
+```
+git clone https://github.com/dvlprlife/Selection-Count
+cd Selection-Count
+npm install
+```
+
+## Running the extension
+
+Open the folder in VS Code and press `F5` ("Run Extension" in `.vscode/launch.json`). It compiles first, then opens an Extension Development Host with the extension loaded. Select some text and watch the status bar.
+
+For a continuous rebuild while editing, run `npm run watch` (parallel esbuild + `tsc --noEmit` watchers).
+
+## Build, lint, test
+
+| Command | What it does |
+| --- | --- |
+| `npm run check-types` | `tsc --noEmit` (strict mode — no `any`, no unused locals/params) |
+| `npm run lint` | ESLint over `src/` |
+| `npm run compile` | Type-check, emit to `dist/`, esbuild bundle |
+| `npm test` | `vscode-test` (downloads VS Code, runs the Mocha suite in `src/test/suite/`); its `pretest` runs `compile` + `lint` first |
+| `node esbuild.js --production` | Production bundle (what CI and packaging use) |
+
+Before committing, all of these must pass (per CLAUDE.md):
+
+```
+npx tsc --noEmit
+node esbuild.js --production
+npm test
+```
+
+On headless Linux, run the tests under xvfb: `xvfb-run -a npm test`.
+
+CI (`.github/workflows/build.yml`) runs exactly that on every PR and push to `main`, across Ubuntu, macOS, and Windows, plus a `vsce package` smoke test on Linux.
+
+## Workflow: issue first, then PR
+
+Every change starts with a GitHub issue (use the issue forms — they capture the what/why/acceptance-criteria structure the repo works from). Then:
+
+1. Branch off `main`, named `issue-{number}-short-description` (kebab-case, 2-4 words), e.g. `issue-12-letter-count-toggle`.
+2. Commit with a brief imperative subject line and `Closes #{number}` in the commit body.
+3. Open a PR whose body starts with `## Summary` (1-3 bullets) and ends with `Closes #{number}` — the PR template scaffolds this.
+
+Hard rules: never push directly to `main`; one PR per issue; don't bundle unrelated work.
+
+Some issues are processed by an automated agent pipeline defined in `agents/` (see `agents/WORKFLOW.md`). Maintainers queue an issue into it by applying the `agent` and `status: need plan` labels — contributors don't need to (and shouldn't) apply those labels or create labels by hand. Don't modify `agents/**` as part of a feature PR; agent workflow changes go in their own PR.
+
+## Tests, CHANGELOG, README
+
+- Any change to the counter functions in `src/counters.ts` requires unit tests covering empty input, ASCII-only, Unicode letters and digits, multiline input, and a multi-range aggregate.
+- User-visible changes (new/changed commands, settings, keybindings, user-facing bug fixes) need an entry under `## [Unreleased]` in `CHANGELOG.md` (Keep a Changelog format) and, for anything user-discoverable, a matching `README.md` update in the same PR. CLAUDE.md spells out exactly what counts.
+- Contributor-facing docs, CI, and test-only changes need neither.
+
+## Project invariants (read before touching `src/`)
+
+CLAUDE.md's "Project conventions" section is non-negotiable: counters are pure functions (no `vscode` imports), all counts render into a single status bar item, configuration drives display not behavior, the extension reacts to selection changes (not document changes), and the exact Unicode definitions of character/word/letter/number/special are specified there.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ All commands are available through the Command Palette (search for "Selection Co
 
 Please file issues and feature requests on [GitHub](https://github.com/dvlprlife/Selection-Count).
 
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup, the build/test commands, and the issue-first workflow.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Add GitHub issue forms (`bug_report.yml` applying the existing `bug` label, `feature_request.yml` applying `enhancement`) plus `config.yml` with `blank_issues_enabled: false`. The feature form captures What / Why / Acceptance criteria to match the issue-body convention in CLAUDE.md; the bug form captures repro, expected behavior, `selectionCount.*` settings + scope, and versions.
- Add `.github/pull_request_template.md` following the CLAUDE.md PR convention (`## Summary` first, `Closes #` last) with a checklist mirroring what CI actually runs (`npx tsc --noEmit`, `node esbuild.js --production`, `npm test`) plus the CHANGELOG/README maintenance rules.
- Add `CONTRIBUTING.md`: setup (Node 20, `npm install`), F5 / `npm run watch` dev loop, the real script table from `package.json`, the pre-commit gate and CI matrix, the issue-first / `issue-{number}-slug` branch workflow, a factual note on the `agents/` pipeline labels (maintainer-applied only), and pointers to CLAUDE.md's test/CHANGELOG/README rules and project invariants.
- Add a two-line `## Contributing` pointer in `README.md` under "Issues and feedback".

Notes:

- No CHANGELOG entry: contributor-facing docs and CI/templates are explicitly out of scope per CLAUDE.md's CHANGELOG rules.
- Branch is `chore/contributor-scaffolding` rather than `issue-{number}-...` because this scaffolding work was directly requested without an issue, and CLAUDE.md forbids creating issues without an approved draft. No `Closes #` for the same reason.
- Verified: all three issue-form YAML files parse with js-yaml; `npx tsc --noEmit` and `npm run lint` pass (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
